### PR TITLE
Allow projects and contexts to contain non-Latin characters

### DIFF
--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -44,11 +44,11 @@ export namespace Patterns {
     // The context and project patterns are prefixed with non-word boundary (\B) as they
     // begin with non-word chars (+@). The tag pattern is prefixed with a word bounday (\b)
     // as tags begin with a word char.
-    export const ContextRegex = /\B@\S+\b/g;
+    export const ContextRegex = /\B@\S+/g;
     export const PriorityWithLeadingSpaceRegex = /^\s*[(][A-Z][)]\B/g;
     export const PriorityWithTrailingSpaceRegex = /[(][A-Z][)]\s/;
     export const PriorityOnlyRegex = /[(][A-Z][)]\B/g;
-    export const ProjectRegex = /\B\+\S+\b/g;
+    export const ProjectRegex = /\B\+\S+/g;
     export const TagRegex = /\b[^\s:]+:[^\s]+\b/g;
     export const CreationDateRegex = /^(?:[(][A-Z][)] )?\s*(\d{4}-\d{2}-\d{2})\s/g;
     export const TagValueRegex = /\b([^\s:]+):(\S+)\b/g;

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -49,9 +49,9 @@ export namespace Patterns {
     export const PriorityWithTrailingSpaceRegex = /[(][A-Z][)]\s/;
     export const PriorityOnlyRegex = /[(][A-Z][)]\B/g;
     export const ProjectRegex = /\B\+\S+/g;
-    export const TagRegex = /\b[^\s:]+:[^\s]+\b/g;
+    export const TagRegex = /[^\s:]+:\S+/g;
     export const CreationDateRegex = /^(?:[(][A-Z][)] )?\s*(\d{4}-\d{2}-\d{2})\s/g;
-    export const TagValueRegex = /\b([^\s:]+):(\S+)\b/g;
+    export const TagValueRegex = /([^\s:]+):(\S+)/g;
     export const TagDateRegexString = "\\b(#TAG#):(\\d{4}-\\d{2}-\\d{2})\\b";
     export const CompletedGlobalRegex = /^\s*x .*$/g;
     export const CompletedRegex = /^\s*x\s/;


### PR DESCRIPTION
Hello.

`\b` token at the end of regex searching pattern blocked Cyrillic and other non-Latin names for projects and contexts to be found and highlighted. Removing it solves the problem though now regex can eat more symbols than it was expected initially. I suppose it's worth.

Before:
![image](https://user-images.githubusercontent.com/1607322/119663204-ceb0b580-be3a-11eb-97ed-200a2d9cb139.png)

After:
![image](https://user-images.githubusercontent.com/1607322/119663322-ec7e1a80-be3a-11eb-9a2e-ced478a3d1c4.png)
