### PR TITLE
Unregister hover providers when unloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.4.30 - 2021-11-16
+
+- Fixed issue on ["Note tag hover shows note content more than once"](https://github.com/davraamides/todotxt-mode/issues/42) where hovers would show note content more than once.
+
 ## 1.4.28 - 2021-10-09
 
 - Added `tagDatePattern` setting to allow specifying format of dates in `due` tags. Addresses [Extension Setting to Change Date Format](https://github.com/davraamides/todotxt-mode/issues/33).

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,8 @@ export function activate(context: vscode.ExtensionContext) {
 		decorator.decorateDocument();
 	});
 
+	let disposable: vscode.Disposable;
+
 	// Register a hover provider for the note:xxx tag which reads the
 	// note file and displays in a hover message with a link to the file.
 	// I've had some issues with note files that are in different paths
@@ -29,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
 	// cannot contain spaces since the tag note:xxx is delimited at the
 	// end by a space.
 
-	vscode.languages.registerHoverProvider({scheme: 'file', language: 'plaintext'}, {
+	disposable = vscode.languages.registerHoverProvider({scheme: 'file', language: 'plaintext'}, {
 		provideHover(document, position, token) {
 			const word = document.getText(document.getWordRangeAtPosition(position, Patterns.TagRegex));
             // vscode.window.showInformationMessage(`word: ${word}`);
@@ -59,7 +61,10 @@ export function activate(context: vscode.ExtensionContext) {
 			return null;
 		}
 	});
-	vscode.languages.registerHoverProvider({scheme: 'file', language: 'plaintext'}, {
+
+	context.subscriptions.push(disposable);
+
+	disposable = vscode.languages.registerHoverProvider({scheme: 'file', language: 'plaintext'}, {
 		provideHover(document, position, token) {
 			const word = document.getText(document.getWordRangeAtPosition(position, Patterns.ProjectRegex));
             // vscode.window.showInformationMessage(`word: ${word}`);
@@ -86,6 +91,9 @@ export function activate(context: vscode.ExtensionContext) {
 			return null;
 		}
 	});
+
+	context.subscriptions.push(disposable);
+
 	// decorate initially on activation
 	decorator.decorateDocument();
 }


### PR DESCRIPTION
This is just a tiny fix for a bug I was having (#42), if you want it. It isn't at all hacky - I've found multiple examples online that suggest this is a standard thing you're supposed to do when registering hover providers, so it really should be there.

Tested it on my computer where I was having the bug, and it seems completely fixed!

![Screenshot from 2021-11-16 19-14-02](https://user-images.githubusercontent.com/25230174/142054152-87a465ff-b640-4da1-860a-a7bf12602620.png)
