### PR TITLE
feat: insert created at on new task

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,11 @@
 					"default": "waiting.txt",
 					"description": "Name of file for deferred/waiting tasks"
 				},
+				"todotxtmode.addCreatedAt": {
+					"type": "boolean",
+					"default": false,
+					"description": "Add the creation date when creating a task"
+				},
 				"todotxtmode.sortCompletedTasksToEnd": {
 					"type": "boolean",
 					"default": true,

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
-import { Helpers } from './helpers';
-import { Settings } from './settings';
+import {Helpers} from './helpers';
+import {Settings} from './settings';
 //
 // Logic to toggle a task completed
 //
@@ -15,6 +15,25 @@ import { Settings } from './settings';
 const TaskCompletionRegEx = /^(\s*)(x )?(\([A-Z]\) )?(\d{4}-\d{2}-\d{2} )?(\d{4}-\d{2}-\d{2} )?(.*)$/;
 
 export namespace Completion {
+
+    /**
+     * Insert the current date of the beginning of the line and move the cursor after
+     */
+    export async function insertCreatedAt() {
+        const editor = vscode.window.activeTextEditor;
+        let [startLine] = Helpers.getSelectedLineRange(false);
+        const line = startLine + 1;
+
+        const [date] = new Date().toISOString().split('T')
+
+        await editor.edit(builder => {
+            builder.insert(new vscode.Position(line, 0), `${date} `);
+        });
+
+        const cursorPos = date.length + 1;
+
+        editor.selection = new vscode.Selection(new vscode.Position(line, cursorPos), new vscode.Position(line, cursorPos));
+    }
 
     export function toggleCompletion() {
         const editor = vscode.window.activeTextEditor;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,6 +15,8 @@ export namespace Settings {
     export const DoneFilename: string = getSetting<string>("doneFilename");
     export const SomedayFilename: string = getSetting<string>("somedayFilename");
     export const WaitingFilename: string = getSetting<string>("waitingFilename");
+
+    export const AddCreatedAt = getSetting<boolean>("addCreatedAt");
     
     export const Message:string = getSetting<string>("message");
     export const SortCompletedTasksToEnd:boolean = getSetting<boolean>("sortCompletedTasksToEnd");
@@ -74,7 +76,7 @@ export namespace Settings {
         opacity: getSetting<string>("completedStyle.opacity")
     };
 
-    function getSetting<T>(field:string): T | undefined {
+    export function getSetting<T>(field:string): T | undefined {
         return vscode.workspace.getConfiguration("todotxtmode").get<T>(field);
     }
 


### PR DESCRIPTION
A quick feature to insert creation date on new tasks.

- added a setting to disable / enable the feature
- listen `onDidChangeTextDocument` to trigger new task (when user enter `\n`)

That's it

![Peek 2023-04-20 22-51](https://user-images.githubusercontent.com/11815139/233485430-b817e039-f102-4cb3-8d9a-42ea782aa215.gif)
